### PR TITLE
bugfix for base boundaries

### DIFF
--- a/CoverTree.java
+++ b/CoverTree.java
@@ -215,7 +215,7 @@ public class CoverTree<E> {
 					}
 					else 
 						n2.distance = n1.distance;
-					if (n2.distance < Math.pow(base,level)) {
+					if (n2.distance <= Math.pow(base,level)) {
 						candidates.add(n2);
 						parentFound = false;
 					}
@@ -227,7 +227,7 @@ public class CoverTree<E> {
 				break;
 			//select one node of the coverset as the parent of the node
 			for (Node<E> n : coverset) {
-				if (n.distance < Math.pow(base,level)) {
+				if (n.distance <= Math.pow(base,level)) {
 					parent = n;
 					parentLevel = level;
 					break;
@@ -363,7 +363,7 @@ public class CoverTree<E> {
 			candidates.clear();
 			//create a set of candidate nearest neighbors
 			for (Node<E> n : newCandidates)
-				if (n.distance < minDist + Math.pow(base,i))
+				if (n.distance <= minDist + Math.pow(base,i))
 					candidates.add(n);
 		}
 		for (Node<E> n : candidates) {


### PR DESCRIPTION
When dist happens to be on exact base boundaries, the wrong decision was being made. For example when the distance between a and b is exactly 1, it will not correctly insert the second node. Leading to wrong size() computation and wrong neighbor retrieval.

Compare change to original algorithm which states <= instead of <.